### PR TITLE
fix deprecations for symfony >= 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,12 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('intaro_twig_sandbox');
-
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
+        $treeBuilder = new TreeBuilder('intaro_twig_sandbox');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('intaro_twig_sandbox');
+        }
 
         return $treeBuilder;
     }


### PR DESCRIPTION
 A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.