### PR TITLE
Strict mode of the TwigSandbox validator

### DIFF
--- a/Validator/Constraints/TwigSandbox.php
+++ b/Validator/Constraints/TwigSandbox.php
@@ -11,6 +11,10 @@ class TwigSandbox extends Constraint
 {
     public string $message = 'This value is not a valid Twig template. The parsing error is: {{ syntax_error }}';
     public string $criticalErrorMessage = 'Critical error occurred while rendering the template. Please check the correctness of template syntax.';
+    /* If true renders twig in mode strict_variables = true */
+    public bool $strict = false;
+    /** @var array<string, class-string> name => fullClassName of vars which will be in context */
+    public array $vars = [];
 
     public function validatedBy(): string
     {

--- a/Validator/Constraints/TwigSandboxValidator.php
+++ b/Validator/Constraints/TwigSandboxValidator.php
@@ -6,6 +6,9 @@ use Intaro\TwigSandboxBundle\Builder\EnvironmentBuilder;
 use Intaro\TwigSandboxBundle\Builder\TwigAdapter;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+use Twig\Sandbox\SecurityError;
 
 class TwigSandboxValidator extends ConstraintValidator
 {
@@ -14,9 +17,12 @@ class TwigSandboxValidator extends ConstraintValidator
     ) {
     }
 
-    public function getTwig(): TwigAdapter
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function getTwig(array $params = []): TwigAdapter
     {
-        return $this->builder->getSandboxEnvironment();
+        return $this->builder->getSandboxEnvironment($params);
     }
 
     /**
@@ -28,17 +34,21 @@ class TwigSandboxValidator extends ConstraintValidator
             return;
         }
 
-        $twig = $this->getTwig();
+        $twig = $this->getTwig([
+            'strict_variables' => $constraint->strict,
+        ]);
+
+        $vars = [];
+        foreach ($constraint->vars as $name => $className) {
+            if (!class_exists($className)) {
+                throw new \RuntimeException(sprintf('Class "%s" does not exist', $className));
+            }
+            $vars[$name] = new $className();
+        }
 
         try {
-            $twig->createTemplate((string) $value);
-        } catch (\Twig\Sandbox\SecurityError $e) {
-            $message = mb_strlen($e->getMessage()) > 150 ? mb_substr($e->getMessage(), 0, 150) . '…' : $e->getMessage();
-
-            $this->context->addViolation($constraint->message, [
-                '{{ syntax_error }}' => $message,
-            ]);
-        } catch (\Twig\Error\SyntaxError $e) {
+            $twig->render((string) $value, $vars);
+        } catch (SecurityError|SyntaxError|RuntimeError $e) {
             $message = mb_strlen($e->getMessage()) > 150 ? mb_substr($e->getMessage(), 0, 150) . '…' : $e->getMessage();
 
             $this->context->addViolation($constraint->message, [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: "#Dead catch - .+? is never thrown in the try block#"
-			count: 1
-			path: Validator/Constraints/TwigSandboxValidator.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,3 @@
-includes:
-    - phpstan-baseline.neon
-
 parameters:
   level: 8
   paths:

--- a/tests/BundleInitializationTest.php
+++ b/tests/BundleInitializationTest.php
@@ -6,9 +6,11 @@ use Intaro\TwigSandboxBundle\Builder\EnvironmentBuilder;
 use Intaro\TwigSandboxBundle\IntaroTwigSandboxBundle;
 use Intaro\TwigSandboxBundle\Tests\fixtures\Entity\Product;
 use Intaro\TwigSandboxBundle\Tests\fixtures\FixtureBundle;
+use Intaro\TwigSandboxBundle\Validator\Constraints\TwigSandbox;
 use Nyholm\BundleTest\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedMethodError;
 
@@ -111,6 +113,64 @@ class BundleInitializationTest extends KernelTestCase
         ]);
 
         $this->assertEquals('Product product 1', $html);
+    }
+
+    public function testValidationIsValid(): void
+    {
+        self::bootKernel();
+        $container = property_exists(__CLASS__, 'container') ? self::$container : self::getContainer();
+
+        /** @var ValidatorInterface $validator */
+        $validator = $container->get(ValidatorInterface::class);
+        $this->assertCount(0, $validator->validate('', new TwigSandbox()));
+        $this->assertCount(0, $validator->validate('ddd', new TwigSandbox()));
+        $this->assertCount(0, $validator->validate('{{ v }}', new TwigSandbox()));
+        $this->assertCount(0, $validator->validate('{{ v.name }}', new TwigSandbox([
+            'strict' => true,
+            'vars' => ['v' => Product::class],
+        ])));
+    }
+
+    public function testValidationIsNotValid(): void
+    {
+        self::bootKernel();
+        $container = property_exists(__CLASS__, 'container') ? self::$container : self::getContainer();
+
+        /** @var ValidatorInterface $validator */
+        $validator = $container->get(ValidatorInterface::class);
+
+        $result = $validator->validate(
+            '{{ v }}',
+            new TwigSandbox(['strict' => true])
+        );
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString(
+            'Variable "v" does not exist',
+            $result->get(0)->getParameters()['{{ syntax_error }}']
+        );
+
+        $result = $validator->validate(
+            '{{ p.name }}{{ v }}',
+            new TwigSandbox([
+                'strict' => true,
+                'vars' => ['p' => Product::class],
+            ])
+        );
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString(
+            'Variable "v" does not exist',
+            $result->get(0)->getParameters()['{{ syntax_error }}']
+        );
+
+        $result = $validator->validate(
+            '{{ ddd',
+            new TwigSandbox()
+        );
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString(
+            'Unexpected token "end of template"',
+            $result->get(0)->getParameters()['{{ syntax_error }}']
+        );
     }
 
     private function getObject(): Product

--- a/tests/BundleInitializationTest.php
+++ b/tests/BundleInitializationTest.php
@@ -10,7 +10,7 @@ use Nyholm\BundleTest\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Twig\Sandbox\SecurityNotAllowedFilterError;
-use Twig\Sandbox\SecurityNotAllowedPropertyError;
+use Twig\Sandbox\SecurityNotAllowedMethodError;
 
 class BundleInitializationTest extends KernelTestCase
 {
@@ -76,8 +76,8 @@ class BundleInitializationTest extends KernelTestCase
 
     public function testRenderError(): void
     {
-        $this->expectException(SecurityNotAllowedPropertyError::class);
-        $this->expectExceptionMessageMatches('/Calling "quantity" property on a ".*Product" object is not allowed in/');
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $this->expectExceptionMessageMatches('/Calling "getquantity" method on a ".*Product" object is not allowed in/');
 
         self::bootKernel();
         $container = property_exists(__CLASS__, 'container') ? self::$container : self::getContainer();

--- a/tests/config/framework.yaml
+++ b/tests/config/framework.yaml
@@ -7,3 +7,5 @@ framework:
         handler_id: ~
     php_errors:
         log: true
+    validation:
+        enabled: true


### PR DESCRIPTION
Strict mode allows to check not existing vars, methods and properties in template